### PR TITLE
fix error return rule to allow multiple error return values

### DIFF
--- a/rule/error-return.go
+++ b/rule/error-return.go
@@ -47,6 +47,9 @@ func (w lintErrorReturn) Visit(n ast.Node) ast.Visitor {
 	if len(ret) <= 1 {
 		return w
 	}
+	if isIdent(ret[len(ret)-1].Type, "error") {
+		return true
+	}
 	// An error return parameter should be the last parameter.
 	// Flag any error parameters found before the last.
 	for _, r := range ret[:len(ret)-1] {


### PR DESCRIPTION
please check golint updates here https://github.com/golang/lint/commit/837967239b74207656c3f550e9dc6a944866c490
When returning multiple values with an error,
lint checks if the error is the last return value.
But the implementation actually is checking for all return values
except for the last one, and throw the alert if it found an error.

There is a (edge) case where some function returning more than one error
is getting a false positive even when the last return value is an error.

This patch adds an early check, to see if the last return value is an error
and if so, it will pass silently.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follows the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
